### PR TITLE
Add dropdown metrics with updated chart colors

### DIFF
--- a/plant-frontend/src/App.vue
+++ b/plant-frontend/src/App.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import LineChart from './components/LineChart.vue'
 
 const plants = ref([
@@ -12,10 +12,14 @@ const selectedPlant = ref(plants.value[0])
 const sidebarOpen = ref(false)
 const lastUpdate = ref(new Date().toLocaleTimeString())
 
-const labels = Array.from({ length: 24 }, (_, i) => `${i + 1}`)
+const labels = Array.from({ length: 24 }, (_, i) => i)
 const moistureData = Array.from({ length: 24 }, () => Math.floor(Math.random() * 40) + 30)
 const temperatureData = Array.from({ length: 24 }, () => Math.floor(Math.random() * 10) + 20)
 const lightData = Array.from({ length: 24 }, () => Math.floor(Math.random() * 100))
+
+const latestMoisture = computed(() => moistureData[moistureData.length - 1])
+const latestTemperature = computed(() => temperatureData[temperatureData.length - 1])
+const latestLight = computed(() => lightData[lightData.length - 1])
 
 function selectPlant(plant) {
   selectedPlant.value = plant
@@ -34,7 +38,7 @@ function selectPlant(plant) {
     ></div>
     <aside
       :class="[
-        'bg-gray-100 w-64 p-4 z-20 transition-transform md:translate-x-0 fixed md:static h-full overflow-y-auto',
+        'bg-green-100 w-64 p-4 z-20 transition-transform md:translate-x-0 fixed md:static h-full overflow-y-auto',
         sidebarOpen ? 'translate-x-0' : '-translate-x-full'
       ]"
     >
@@ -82,16 +86,34 @@ function selectPlant(plant) {
         <span class="text-sm text-gray-500">Last Update: {{ lastUpdate }}</span>
       </div>
       <!-- Dashboard Charts -->
-      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-        <div class="bg-white rounded shadow p-4 h-48">
-          <LineChart :labels="labels" :values="moistureData" y-label="Moisture (%)" />
-        </div>
-        <div class="bg-white rounded shadow p-4 h-48">
-          <LineChart :labels="labels" :values="temperatureData" y-label="Temperature (°C)" />
-        </div>
-        <div class="bg-white rounded shadow p-4 h-48">
-          <LineChart :labels="labels" :values="lightData" y-label="Light" />
-        </div>
+      <div class="space-y-4">
+        <details class="bg-white rounded shadow p-4">
+          <summary class="cursor-pointer text-lg mb-2">
+            <span class="font-bold">Moisture:</span>
+            <span class="font-bold text-sky-600"> {{ latestMoisture }}%</span>
+          </summary>
+          <div class="h-48">
+            <LineChart :labels="labels" :values="moistureData" y-label="Moisture (%)" color="#87CEEB" />
+          </div>
+        </details>
+        <details class="bg-white rounded shadow p-4">
+          <summary class="cursor-pointer text-lg mb-2">
+            <span class="font-bold">Temperature:</span>
+            <span class="font-bold text-red-600"> {{ latestTemperature }}°C</span>
+          </summary>
+          <div class="h-48">
+            <LineChart :labels="labels" :values="temperatureData" y-label="Temperature (°C)" color="#FF6347" />
+          </div>
+        </details>
+        <details class="bg-white rounded shadow p-4">
+          <summary class="cursor-pointer text-lg mb-2">
+            <span class="font-bold">Light:</span>
+            <span class="font-bold text-yellow-600"> {{ latestLight }}</span>
+          </summary>
+          <div class="h-48">
+            <LineChart :labels="labels" :values="lightData" y-label="Light" color="#FFD700" />
+          </div>
+        </details>
       </div>
     </div>
   </div>
@@ -99,6 +121,6 @@ function selectPlant(plant) {
 
 <style>
 body {
-  @apply bg-gray-50;
+  @apply bg-green-50;
 }
 </style>

--- a/plant-frontend/src/components/LineChart.vue
+++ b/plant-frontend/src/components/LineChart.vue
@@ -19,6 +19,10 @@ const props = defineProps({
   yLabel: {
     type: String,
     required: true
+  },
+  color: {
+    type: String,
+    default: 'rgb(75, 192, 192)'
   }
 })
 
@@ -29,7 +33,7 @@ const chartData = {
       label: props.yLabel,
       data: props.values,
       fill: false,
-      borderColor: 'rgb(75, 192, 192)',
+      borderColor: props.color,
       tension: 0.4
     }
   ]
@@ -40,9 +44,11 @@ const chartOptions = {
   maintainAspectRatio: false,
   scales: {
     x: {
-      title: {
-        display: true,
-        text: 'Time'
+      ticks: {
+        callback: (val, index) =>
+          index % 4 === 0
+            ? `${String(props.labels[index]).padStart(2, '0')}:00`
+            : ''
       }
     },
     y: {


### PR DESCRIPTION
## Summary
- let each metric open a dropdown showing the chart
- show latest reading when dropdown is closed
- colorize each chart: moisture sky blue, temperature tomato red, light yellow
- remove x-axis label and only mark every 4 hours
- give the layout a more nature like palette

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856de641e748330857b5b17988df8db