### PR TITLE
Improve metrics layout and graph display

### DIFF
--- a/plant-frontend/src/App.vue
+++ b/plant-frontend/src/App.vue
@@ -54,51 +54,77 @@ const metricColor = computed(() => {
   }
 })
 
+const metricMin = computed(() => {
+  switch (selectedMetric.value) {
+    case 'moisture':
+      return 0
+    case 'temperature':
+      return 0
+    case 'light':
+      return 0
+    default:
+      return 0
+  }
+})
+
+const metricMax = computed(() => {
+  switch (selectedMetric.value) {
+    case 'moisture':
+      return 100
+    case 'temperature':
+      return 40
+    case 'light':
+      return 100
+    default:
+      return 100
+  }
+})
+
 function showMetric(metric) {
   selectedMetric.value = metric
 }
 </script>
 
 <template>
-  <div class="min-h-screen bg-white p-4">
+  <div class="min-h-screen bg-gray-100 p-4">
     <h1 class="text-2xl font-bold text-center mb-6">{{ plantName }}</h1>
-    <div class="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-6">
+    <div class="flex flex-nowrap gap-4 mb-6">
       <div
         @click="showMetric('overall')"
-        class="cursor-pointer bg-gray-50 rounded shadow flex flex-col items-center justify-center p-4"
+        class="cursor-pointer bg-white rounded shadow flex flex-col items-center justify-center p-4 flex-1"
       >
         <span class="text-3xl">🌱</span>
         <span class="mt-2 font-semibold text-center">Overall Health</span>
       </div>
       <div
         @click="showMetric('moisture')"
-        class="cursor-pointer bg-gray-50 rounded shadow flex flex-col items-center justify-center p-4"
+        class="cursor-pointer bg-white rounded shadow flex flex-col items-center justify-center p-4 flex-1"
       >
         <span class="text-xl font-bold">{{ latestMoisture }}%</span>
         <span class="text-sm text-center">Soil Moisture</span>
       </div>
       <div
         @click="showMetric('temperature')"
-        class="cursor-pointer bg-gray-50 rounded shadow flex flex-col items-center justify-center p-4"
+        class="cursor-pointer bg-white rounded shadow flex flex-col items-center justify-center p-4 flex-1"
       >
         <span class="text-xl font-bold">{{ latestTemperature }}°C</span>
         <span class="text-sm text-center">Temperature</span>
       </div>
       <div
         @click="showMetric('light')"
-        class="cursor-pointer bg-gray-50 rounded shadow flex flex-col items-center justify-center p-4"
-      >
+        class="cursor-pointer bg-white rounded shadow flex flex-col items-center justify-center p-4 flex-1"
+    >
         <span class="text-xl font-bold">{{ latestLight }}</span>
         <span class="text-sm text-center">Light clux</span>
       </div>
     </div>
-    <div class="bg-gray-50 rounded shadow p-4 flex flex-col items-center" style="height: 20rem;">
+    <div class="bg-white rounded shadow p-4 flex flex-col items-center" style="height: 20rem;">
       <h2 class="font-semibold mb-2">{{ metricHeader }}</h2>
       <div v-if="selectedMetric === 'overall'" class="flex items-center justify-center flex-1 text-xl">
         Your plant is healthy
       </div>
       <div v-else class="w-full h-full">
-        <LineChart :labels="labels" :values="metricData" :color="metricColor" />
+        <LineChart :labels="labels" :values="metricData" :color="metricColor" :min="metricMin" :max="metricMax" />
       </div>
     </div>
   </div>

--- a/plant-frontend/src/components/LineChart.vue
+++ b/plant-frontend/src/components/LineChart.vue
@@ -20,6 +20,14 @@ const props = defineProps({
     type: String,
     default: ''
   },
+  min: {
+    type: Number,
+    default: 0
+  },
+  max: {
+    type: Number,
+    default: null
+  },
   color: {
     type: String,
     default: 'rgb(75, 192, 192)'
@@ -48,11 +56,19 @@ const chartOptions = {
   scales: {
     x: {
       grid: { display: false },
-      ticks: { display: false }
+      ticks: {
+        display: true,
+        color: '#4B5563',
+      }
     },
     y: {
       grid: { display: false },
-      ticks: { display: false }
+      suggestedMin: props.min,
+      suggestedMax: props.max,
+      ticks: {
+        display: true,
+        color: '#4B5563'
+      }
     }
   }
 }

--- a/plant-frontend/src/style.css
+++ b/plant-frontend/src/style.css
@@ -3,5 +3,5 @@
 @tailwind utilities;
 
 body {
-  @apply bg-white;
+  @apply bg-gray-100;
 }


### PR DESCRIPTION
## Summary
- keep page background off white
- place metric cards in a single row and make them white
- update line chart component to support axis ticks and min/max values
- show proper y‑axis ranges for each metric

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685eaf5e223c8330896181f6e33f48ec